### PR TITLE
feat: CLIN-1179 - replace cqgc_link with size

### DIFF
--- a/src/main/scala/bio/ferlab/clin/etl/task/ldmnotifier/TasksGqlExtractor.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/task/ldmnotifier/TasksGqlExtractor.scala
@@ -40,6 +40,9 @@ object TasksGqlExtractor {
          |						  url
          |              hash64: hash
          |              title
+         |              size: extension(url: "http://fhir.cqgc.ferlab.bio/StructureDefinition/full-size") @flatten @first { 
+         |                size: value
+         |              } 
          |		  		   }
          |             format @flatten {
          |              fileFormat: code

--- a/src/main/scala/bio/ferlab/clin/etl/task/ldmnotifier/TasksMessageComposer.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/task/ldmnotifier/TasksMessageComposer.scala
@@ -19,7 +19,7 @@ object TasksMessageComposer {
       "ldm_sample_id",
       "patient_id",
       "service_request_id",
-      "cqgc_link"
+      "size"
     )
     pW.write(s"${header.mkString("\t")}\n")
     rows.foreach(row => {
@@ -32,7 +32,7 @@ object TasksMessageComposer {
         row.ldmSampleId,
         row.patientId,
         row.serviceRequestId,
-        row.cqgcLink
+        row.size
       )
       pW.write(s"${values.mkString("\t")}\n")
     })

--- a/src/main/scala/bio/ferlab/clin/etl/task/ldmnotifier/TasksTransformer.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/task/ldmnotifier/TasksTransformer.scala
@@ -46,7 +46,7 @@ object TasksTransformer {
           ldmSampleId = sampleId,
           patientId = patientId,
           serviceRequestId = removePrefix(serviceRequestReferencePrefix, serviceRequestReference),
-          cqgcLink = makeCqgcLink(clinUrl, patientId)
+          size = content.attachment.size
         )
       )
     })

--- a/src/main/scala/bio/ferlab/clin/etl/task/ldmnotifier/model/ManifestRow.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/task/ldmnotifier/model/ManifestRow.scala
@@ -9,5 +9,5 @@ case class ManifestRow(
                         ldmSampleId: String,
                         patientId: String,
                         serviceRequestId: String,
-                        cqgcLink: String
+                        size: Long
                       )

--- a/src/main/scala/bio/ferlab/clin/etl/task/ldmnotifier/model/Task.scala
+++ b/src/main/scala/bio/ferlab/clin/etl/task/ldmnotifier/model/Task.scala
@@ -2,7 +2,7 @@ package bio.ferlab.clin.etl.task.ldmnotifier.model
 
 import play.api.libs.json.{Json, Reads}
 
-case class Attachment(url: String, hash64: Option[String], title: String)
+case class Attachment(url: String, hash64: Option[String], title: String, size: Long)
 object Attachment {
   implicit val reads: Reads[Attachment] = Json.reads[Attachment]
 }

--- a/src/test/resources/task/graphql_http_resp_run_name_1.json
+++ b/src/test/resources/task/graphql_http_resp_run_name_1.json
@@ -16,14 +16,16 @@
                 "attachment": {
                   "url": "https://ferload.qa.clin.ferlab.bio/blue/9d7f1860-dc3a-4568-a5fa-007c3e3655ec",
                   "hash64": "YzFkY2U1ZjVmNmE0ZDBhNTlkMzlhY2I5MTlkOGViOGM=",
-                  "title": "16900.cram"
+                  "title": "16900.cram",
+                  "size": 1024
                 },
                 "fileFormat": "CRAM"
               },
               {
                 "attachment": {
                   "url": "https://ferload.qa.clin.ferlab.bio/blue/9d7f1860-dc3a-4568-a5fa-007c3e3655ec.crai",
-                  "title": "16900.cram.crai"
+                  "title": "16900.cram.crai",
+                  "size": 1024
                 },
                 "fileFormat": "CRAI"
               }
@@ -40,14 +42,16 @@
                 "attachment": {
                   "url": "https://ferload.qa.clin.ferlab.bio/blue/fbc89c72-a6ca-4b23-9078-f6f566c0ba92",
                   "hash64": "ZDMwODRkOWY2NGZmYjQxZTRjZWE0ZjJiY2M5ZmQxYjA=",
-                  "title": "16900.hard-filtered.gvcf.gz"
+                  "title": "16900.hard-filtered.gvcf.gz",
+                  "size": 1024
                 },
                 "fileFormat": "VCF"
               },
               {
                 "attachment": {
                   "url": "https://ferload.qa.clin.ferlab.bio/blue/fbc89c72-a6ca-4b23-9078-f6f566c0ba92.tbi",
-                  "title": "16900.hard-filtered.gvcf.gz.tbi"
+                  "title": "16900.hard-filtered.gvcf.gz.tbi",
+                  "size": 1024
                 },
                 "fileFormat": "TBI"
               }
@@ -64,14 +68,16 @@
                 "attachment": {
                   "url": "https://ferload.qa.clin.ferlab.bio/blue/5944c2e6-9614-4712-a762-6825037ab841",
                   "hash64": "NDIyNTE3YTdiZjIxNTliYmNhMTA5ZDIzMWI1ZWMyYzk=",
-                  "title": "16900.cnv.vcf.gz"
+                  "title": "16900.cnv.vcf.gz",
+                  "size": 1024
                 },
                 "fileFormat": "VCF"
               },
               {
                 "attachment": {
                   "url": "https://ferload.qa.clin.ferlab.bio/blue/5944c2e6-9614-4712-a762-6825037ab841.tbi",
-                  "title": "16900.cnv.vcf.gz.tbi"
+                  "title": "16900.cnv.vcf.gz.tbi",
+                  "size": 1024
                 },
                 "fileFormat": "TBI"
               }
@@ -87,7 +93,8 @@
               {
                 "attachment": {
                   "url": "https://ferload.qa.clin.ferlab.bio/blue/0400a676-b38e-402a-9cdb-b603d201c433",
-                  "title": "16900.QC.tgz"
+                  "title": "16900.QC.tgz",
+                  "size": 1024
                 },
                 "fileFormat": "TGZ"
               }
@@ -115,14 +122,16 @@
                 "attachment": {
                   "url": "https://ferload.qa.clin.ferlab.bio/blue/10b5c747-219c-4f7b-a0cf-e8dee3a22b61",
                   "hash64": "ZGQ5MjQ3ZWEyZTVjMjkzMTFiMWMyZTU2MTI4ZjFlMzU=",
-                  "title": "16902.cram"
+                  "title": "16902.cram",
+                  "size": 1024
                 },
                 "fileFormat": "CRAM"
               },
               {
                 "attachment": {
                   "url": "https://ferload.qa.clin.ferlab.bio/blue/10b5c747-219c-4f7b-a0cf-e8dee3a22b61.crai",
-                  "title": "16902.cram.crai"
+                  "title": "16902.cram.crai",
+                  "size": 1024
                 },
                 "fileFormat": "CRAI"
               }
@@ -139,14 +148,16 @@
                 "attachment": {
                   "url": "https://ferload.qa.clin.ferlab.bio/blue/b43f727c-5ee9-4403-a83f-862da5b05b54",
                   "hash64": "Mzc4OGM0ZjkwOGNhN2ZmM2NiM2FmNWJjOGI2Mzc3Zjg=",
-                  "title": "16902.hard-filtered.gvcf.gz"
+                  "title": "16902.hard-filtered.gvcf.gz",
+                  "size": 1024
                 },
                 "fileFormat": "VCF"
               },
               {
                 "attachment": {
                   "url": "https://ferload.qa.clin.ferlab.bio/blue/b43f727c-5ee9-4403-a83f-862da5b05b54.tbi",
-                  "title": "16902.hard-filtered.gvcf.gz.tbi"
+                  "title": "16902.hard-filtered.gvcf.gz.tbi",
+                  "size": 1024
                 },
                 "fileFormat": "TBI"
               }
@@ -163,14 +174,16 @@
                 "attachment": {
                   "url": "https://ferload.qa.clin.ferlab.bio/blue/b314e495-e368-4fa5-af05-060a390219e7",
                   "hash64": "NDIyNTE3YTdiZjIxNTliYmNhMTA5ZDIzMWI1ZWMyYzk=",
-                  "title": "16902.cnv.vcf.gz"
+                  "title": "16902.cnv.vcf.gz",
+                  "size": 1024
                 },
                 "fileFormat": "VCF"
               },
               {
                 "attachment": {
                   "url": "https://ferload.qa.clin.ferlab.bio/blue/b314e495-e368-4fa5-af05-060a390219e7.tbi",
-                  "title": "16902.cnv.vcf.gz.tbi"
+                  "title": "16902.cnv.vcf.gz.tbi",
+                  "size": 1024
                 },
                 "fileFormat": "TBI"
               }
@@ -186,7 +199,8 @@
               {
                 "attachment": {
                   "url": "https://ferload.qa.clin.ferlab.bio/blue/513079a1-1642-407c-98d6-b6dc2451cf67",
-                  "title": "16902.QC.tgz"
+                  "title": "16902.QC.tgz",
+                  "size": 1024
                 },
                 "fileFormat": "TGZ"
               }

--- a/src/test/scala/bio/ferlab/clin/etl/task/ldmnotifier/TasksTransformerSpec.scala
+++ b/src/test/scala/bio/ferlab/clin/etl/task/ldmnotifier/TasksTransformerSpec.scala
@@ -18,7 +18,8 @@ class TasksTransformerSpec extends FlatSpec with GivenWhenThen {
               attachment = Attachment(
                 url = "https://ferload.env.clin.ferlab.bio/ldm1file1",
                 hash64 = Some("OWY3Y2Y5YzFjN2E2MWU2NDVkM2MzYzAyYmFhYzI0MGM="),
-                title = "16900.cram.cram"
+                title = "16900.cram.cram",
+                size = 1024
               ),
               fileFormat = "CRAM"
             ),
@@ -26,7 +27,8 @@ class TasksTransformerSpec extends FlatSpec with GivenWhenThen {
               attachment = Attachment(
                 url = "https://ferload.env.clin.ferlab.bio/ldm1file1.crai",
                 hash64 = None,
-                title = "16900.cram.crai"
+                title = "16900.cram.crai",
+                size = 2048
               ),
               fileFormat = "CRAI"
             )
@@ -48,7 +50,8 @@ class TasksTransformerSpec extends FlatSpec with GivenWhenThen {
               attachment = Attachment(
                 url = "https://ferload.env.clin.ferlab.bio/ldm1file2",
                 hash64 = Some("YWMzN2RhMWViOTgwMzQ3NzQ2NWU5ZjgwZDM0NzE2ZmQ"),
-                title = "16870.hard-filtered.gvcf.gz"
+                title = "16870.hard-filtered.gvcf.gz",
+                size = 1024
               ),
               fileFormat = "VCF"
             ),
@@ -56,7 +59,8 @@ class TasksTransformerSpec extends FlatSpec with GivenWhenThen {
               attachment = Attachment(
                 url = "https://ferload.env.clin.ferlab.bio/ldm1file2.tbi",
                 hash64 = None,
-                title = "16870.hard-filtered.gvcf.gz.tbi"
+                title = "16870.hard-filtered.gvcf.gz.tbi",
+                size = 2048
               ),
               fileFormat = "TBI"
             )
@@ -78,7 +82,8 @@ class TasksTransformerSpec extends FlatSpec with GivenWhenThen {
               attachment = Attachment(
                 url = "https://ferload.env.clin.ferlab.bio/ldm2file1.tbi",
                 hash64 = None,
-                title = "16870.QC.tgz"
+                title = "16870.QC.tgz",
+                size = 1024
               ),
               fileFormat = "TGZ"
             )
@@ -115,7 +120,7 @@ class TasksTransformerSpec extends FlatSpec with GivenWhenThen {
         ldmSampleId = "sampleId",
         patientId = "1",
         serviceRequestId = "1",
-        cqgcLink = "https://clin.bio/patient/1"
+        size = 1024
       ),
       ManifestRow(
         url = "/ldm1file1.crai",
@@ -126,7 +131,7 @@ class TasksTransformerSpec extends FlatSpec with GivenWhenThen {
         ldmSampleId = "sampleId",
         patientId = "1",
         serviceRequestId = "1",
-        cqgcLink = "https://clin.bio/patient/1"
+        size = 2048
       ),
       ManifestRow(
         url = "/ldm1file2",
@@ -137,7 +142,7 @@ class TasksTransformerSpec extends FlatSpec with GivenWhenThen {
         ldmSampleId = "sampleId",
         patientId = "2",
         serviceRequestId = "2",
-        cqgcLink = "https://clin.bio/patient/2"
+        size = 1024
       ),
       ManifestRow(
         url = "/ldm1file2.tbi",
@@ -148,7 +153,7 @@ class TasksTransformerSpec extends FlatSpec with GivenWhenThen {
         ldmSampleId = "sampleId",
         patientId = "2",
         serviceRequestId = "2",
-        cqgcLink = "https://clin.bio/patient/2"
+        size = 2048
       )
     )
     group(("LDM2", "LDM2@mail.com")) shouldBe Seq(
@@ -161,7 +166,7 @@ class TasksTransformerSpec extends FlatSpec with GivenWhenThen {
         ldmSampleId = "sampleId",
         patientId = "3",
         serviceRequestId = "3",
-        cqgcLink = "https://clin.bio/patient/3"
+        size = 1024
       )
     )
   }


### PR DESCRIPTION
Replace cqgc_link column with size

https://ferlab-crsj.atlassian.net/browse/CLIN-1179


```
url	file_name	file_type	file_format	hash	ldm_sample_id	patient_id	service_request_id	size
/green/fb3e8df1-fc12-4ef4-bfdf-82bfc6baf4a5	16800.cram	ALIR	CRAM	e820e9869f7067a2d4494bc55427320e	12-286	482917	482913	2827488100
/green/fb3e8df1-fc12-4ef4-bfdf-82bfc6baf4a5.crai	16800.cram.crai	ALIR	CRAI		12-286	482917	482913	345598
/green/24c87bbd-0809-4126-bcb5-d2277e83c150	16800.hard-filtered.gvcf.gz	SNV	VCF	0a9e2a7b2825e60bb9c851cf5a9b42bb	12-286	482917	482913	162425489
/green/24c87bbd-0809-4126-bcb5-d2277e83c150.tbi	16800.hard-filtered.gvcf.gz.tbi	SNV	TBI		12-286	482917	482913	1224127
```